### PR TITLE
feat: account creation modal and entry form refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .claude
 CLAUDE.md
 .impeccable
+dist

--- a/frontend/src/components/NewNoTradeEntry.tsx
+++ b/frontend/src/components/NewNoTradeEntry.tsx
@@ -1,4 +1,4 @@
-import { useForm } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import { createNoTradeEntry } from "../api/api";
 import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
@@ -8,14 +8,21 @@ import { useState } from "react";
 import { CreateNoTradeEntryData } from "../types/noTradeEntry.types";
 import { getAccounts } from "../api/api";
 import AccountModal from "./AccountModal";
+import Select from "./Select";
 import {
   formInputStyles as inputStyles,
-  formSelectStyles as selectStyles,
   formLabelStyles as labelStyles,
   formErrorStyles as errorStyles,
 } from "../utils/styleConstants";
 import LoadingSpinner from "./LoadingSpinner";
 import ErrorState from "./ErrorState";
+
+const SectionHeader = ({ label }: { label: string }) => (
+  <div className="flex items-center gap-3 mb-4">
+    <span className="text-xs font-medium text-ink-muted tracking-[0.01em]">{label}</span>
+    <div className="flex-1 h-px bg-border" />
+  </div>
+);
 
 const NewNoTradeEntry = () => {
   const {
@@ -23,6 +30,7 @@ const NewNoTradeEntry = () => {
     handleSubmit,
     reset,
     setValue,
+    control,
     formState: { errors, isDirty },
   } = useForm<CreateNoTradeEntryData>({ mode: "onTouched" });
   const queryClient = useQueryClient();
@@ -31,7 +39,6 @@ const NewNoTradeEntry = () => {
   const [uploadedImages, setUploadedImages] = useState<string[]>([]);
   const [cancelConfirming, setCancelConfirming] = useState(false);
   const [addingAccount, setAddingAccount] = useState(false);
-  const [selectedAccountId, setSelectedAccountId] = useState("");
 
   const handleCancel = () => {
     if (!isDirty && !notes) {
@@ -74,137 +81,150 @@ const NewNoTradeEntry = () => {
     addEntryMutation.mutate({ ...data, notes, images: uploadedImages });
   };
 
-  const { onChange: rhfAccountOnChange, ...accountRest } = register("accountId", {
-    required: "Selecting a trading account is required.",
-  });
+  const accountOptions = [
+    ...(accounts?.map((a) => ({ value: a._id, label: a.accountName })) ?? []),
+    { value: "__new__", label: "+ Add new account" },
+  ];
 
   return (
-    <div className="px-8 py-10">
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="max-w-[800px] mx-auto bg-surface p-8 rounded-2xl border border-border grid grid-cols-1 gap-5"
-    >
-      {/* Header */}
-      <div className="mb-2 pb-4 border-b border-border">
-        <div className="flex items-start justify-between gap-4">
-          <h2 className="text-2xl font-semibold text-ink-primary">Log No Trade Day</h2>
-          <div className="flex items-center gap-2 pt-0.5">
-            {cancelConfirming ? (
-              <>
-                <span className="text-xs text-ink-secondary">Discard changes?</span>
+    <div className="px-4 py-8 sm:px-8">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="max-w-4xl mx-auto bg-surface rounded-2xl border border-border overflow-hidden flex flex-col"
+      >
+        {/* Header */}
+        <div className="px-8 py-6 border-b border-border">
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-xl font-semibold text-ink-primary">Log No Trade Day</h2>
+            <div className="flex items-center gap-2">
+              {cancelConfirming ? (
+                <>
+                  <span className="text-xs text-ink-secondary">Discard changes?</span>
+                  <button
+                    type="button"
+                    className="px-2.5 py-1 bg-ink-primary text-white rounded-md text-xs font-medium cursor-pointer hover:bg-ink-secondary transition-colors duration-150"
+                    onClick={() => navigate(-1)}
+                  >
+                    Discard
+                  </button>
+                  <button
+                    type="button"
+                    className="px-2.5 py-1 bg-transparent text-ink-secondary border border-border rounded-md text-xs font-medium cursor-pointer hover:bg-surface-alt transition-colors duration-150"
+                    onClick={() => setCancelConfirming(false)}
+                  >
+                    Keep editing
+                  </button>
+                </>
+              ) : (
                 <button
                   type="button"
-                  className="px-2.5 py-1 bg-red-500 text-white rounded-md text-xs font-medium cursor-pointer hover:bg-red-600 transition-colors duration-100"
-                  onClick={() => navigate(-1)}
+                  className="px-3.5 py-1.5 bg-transparent text-ink-secondary border border-border rounded-md text-sm cursor-pointer hover:bg-surface-alt transition-colors duration-150"
+                  onClick={handleCancel}
                 >
-                  Discard
+                  Cancel
                 </button>
-                <button
-                  type="button"
-                  className="px-2.5 py-1 bg-transparent text-ink-secondary border border-border rounded-md text-xs font-medium cursor-pointer hover:bg-surface-alt transition-colors duration-100"
-                  onClick={() => setCancelConfirming(false)}
-                >
-                  Keep editing
-                </button>
-              </>
-            ) : (
-              <button
-                type="button"
-                className="px-3.5 py-1.5 bg-transparent text-ink-secondary border border-border rounded-md text-sm cursor-pointer hover:bg-surface-alt transition-colors duration-100"
-                onClick={handleCancel}
-              >
-                Cancel
-              </button>
-            )}
+              )}
+            </div>
           </div>
+          {addEntryMutation.error && (
+            <p className="mt-4 text-sm text-ink-secondary bg-surface-alt border border-border rounded-lg px-3 py-2">
+              {addEntryMutation.error.message}
+            </p>
+          )}
         </div>
-        {addEntryMutation.error && (
-          <p className="mt-3 text-sm text-ink-secondary bg-surface-alt border border-border rounded-md px-3 py-2">
-            {addEntryMutation.error.message}
-          </p>
-        )}
-      </div>
 
-      {/* Account */}
-      <div>
-        <label className={labelStyles}>Trading Account</label>
-        {accounts && accounts.length === 0 ? (
+        {/* Body */}
+        <div className="flex flex-col lg:flex-row">
+
+          {/* Left: Session Metadata */}
+          <div className="lg:w-[280px] shrink-0 px-8 py-7 flex flex-col gap-5">
+            <SectionHeader label="Session" />
+
+            <div>
+              <label className={labelStyles} htmlFor="nte-accountId">Trading Account</label>
+              {accounts && accounts.length === 0 ? (
+                <button
+                  type="button"
+                  onClick={() => setAddingAccount(true)}
+                  className="text-sm text-ink-muted hover:text-ink-primary transition-colors duration-150 cursor-pointer"
+                >
+                  New Account
+                </button>
+              ) : (
+                <Controller
+                  control={control}
+                  name="accountId"
+                  rules={{ required: "Selecting a trading account is required." }}
+                  render={({ field }) => (
+                    <Select
+                      id="nte-accountId"
+                      name={field.name}
+                      value={field.value ?? ""}
+                      onChange={(val) => {
+                        if (val === "__new__") {
+                          setAddingAccount(true);
+                        } else {
+                          field.onChange(val);
+                        }
+                      }}
+                      onBlur={field.onBlur}
+                      options={accountOptions}
+                      placeholder="Select account"
+                    />
+                  )}
+                />
+              )}
+              {errors.accountId && (
+                <span className={errorStyles}>{errors.accountId.message}</span>
+              )}
+            </div>
+
+            <div>
+              <label className={labelStyles} htmlFor="nte-entryTime">Date</label>
+              <input
+                id="nte-entryTime"
+                type="date"
+                className={inputStyles}
+                {...register("entryTime", { required: "Date is required" })}
+              />
+              {errors.entryTime && (
+                <span className={errorStyles}>{errors.entryTime.message}</span>
+              )}
+            </div>
+          </div>
+
+          {/* Right: Notes + Images */}
+          <div className="flex-1 min-w-0 border-t border-border lg:border-t-0 lg:border-l bg-surface-alt px-6 py-7 flex flex-col gap-6">
+            <div className="flex-1 flex flex-col">
+              <label className={labelStyles}>Notes</label>
+              <TextEditor onChange={setNotes} />
+            </div>
+            <div>
+              <label className={labelStyles}>Images</label>
+              <ImageUpload onChange={setUploadedImages} maxImages={5} />
+            </div>
+          </div>
+
+        </div>
+
+        {/* Footer */}
+        <div className="px-8 py-5 border-t border-border">
           <button
-            type="button"
-            onClick={() => setAddingAccount(true)}
-            className="text-sm text-ink-muted hover:text-ink-primary transition-colors duration-150 cursor-pointer"
+            type="submit"
+            className="w-full py-2.5 bg-accent text-white rounded-lg text-sm font-semibold cursor-pointer transition-colors duration-150 hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={addEntryMutation.isPending}
           >
-            New Account
+            {addEntryMutation.isPending ? "Submitting..." : "Log No Trade Day"}
           </button>
-        ) : (
-          <select
-            className={selectStyles}
-            {...accountRest}
-            value={selectedAccountId}
-            onChange={(e) => {
-              if (e.target.value === "__new__") {
-                setAddingAccount(true);
-                setSelectedAccountId("");
-                setValue("accountId", "", { shouldValidate: false });
-              } else {
-                setSelectedAccountId(e.target.value);
-                rhfAccountOnChange(e);
-              }
-            }}
-          >
-            <option value="">Select a trading account</option>
-            {accounts?.map((account) => (
-              <option value={account._id} key={account._id}>{account.accountName}</option>
-            ))}
-            <option value="__new__">Add new account</option>
-          </select>
-        )}
-        {errors.accountId && (
-          <span className={errorStyles}>{errors.accountId.message}</span>
-        )}
-      </div>
+        </div>
+      </form>
 
       {addingAccount && (
         <AccountModal
           onClose={() => setAddingAccount(false)}
-          onSuccess={(acc) => { setSelectedAccountId(acc._id); setValue("accountId", acc._id); }}
+          onSuccess={(acc) => setValue("accountId", acc._id)}
         />
       )}
-
-      {/* Date */}
-      <div>
-        <label className={labelStyles}>Date</label>
-        <input
-          type="date"
-          className={inputStyles}
-          {...register("entryTime", { required: "Date is required" })}
-        />
-        {errors.entryTime && (
-          <span className={errorStyles}>{errors.entryTime.message}</span>
-        )}
-      </div>
-
-      {/* Notes */}
-      <div>
-        <label className={labelStyles}>Notes</label>
-        <TextEditor onChange={setNotes} />
-      </div>
-
-      {/* Images */}
-      <div>
-        <label className={labelStyles}>Images</label>
-        <ImageUpload onChange={setUploadedImages} maxImages={5} />
-      </div>
-
-      {/* Submit */}
-      <button
-        type="submit"
-        className="w-full py-3 bg-accent text-white rounded-lg text-sm font-semibold cursor-pointer transition-colors duration-150 hover:bg-accent-hover mt-2 disabled:opacity-50 disabled:cursor-not-allowed"
-        disabled={addEntryMutation.isPending}
-      >
-        {addEntryMutation.isPending ? "Submitting..." : "Submit"}
-      </button>
-    </form>
     </div>
   );
 };

--- a/frontend/src/components/NewTradeEntry.tsx
+++ b/frontend/src/components/NewTradeEntry.tsx
@@ -1,4 +1,4 @@
-import { useForm } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import { createTradeEntry } from "../api/api";
 import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
@@ -6,9 +6,9 @@ import { CreateTradeEntryData } from "../types/tradeEntry.types";
 import { getAccounts } from "../api/api";
 import { useState } from "react";
 import AccountModal from "./AccountModal";
+import Select from "./Select";
 import {
   formInputStyles as inputStyles,
-  formSelectStyles as selectStyles,
   formLabelStyles as labelStyles,
   formErrorStyles as errorStyles,
 } from "../utils/styleConstants";
@@ -17,12 +17,20 @@ import ErrorState from "./ErrorState";
 import ImageUpload from "./ImageUpload";
 import TextEditor from "./TextEditor";
 
+const SectionHeader = ({ label }: { label: string }) => (
+  <div className="flex items-center gap-3 mb-4">
+    <span className="text-xs font-medium text-ink-muted tracking-[0.01em]">{label}</span>
+    <div className="flex-1 h-px bg-border" />
+  </div>
+);
+
 const NewEntry = () => {
   const {
     register,
     handleSubmit,
     reset,
     setValue,
+    control,
     formState: { errors, isDirty },
   } = useForm<CreateTradeEntryData>({ mode: "onTouched" });
   const queryClient = useQueryClient();
@@ -31,7 +39,6 @@ const NewEntry = () => {
   const [addingAccount, setAddingAccount] = useState(false);
   const [uploadedImages, setUploadedImages] = useState<string[]>([]);
   const [notes, setNotes] = useState<string>("");
-  const [selectedAccountId, setSelectedAccountId] = useState("");
 
   const addEntryMutation = useMutation({
     mutationFn: createTradeEntry,
@@ -74,302 +81,363 @@ const NewEntry = () => {
     addEntryMutation.mutate({ ...data, notes, images: uploadedImages });
   };
 
-  const { onChange: rhfAccountOnChange, ...accountRest } = register("accountId", {
-    required: "Selecting a trading account is required.",
-  });
+  const accountOptions = [
+    ...(accounts?.map((a) => ({ value: a._id, label: a.accountName })) ?? []),
+    { value: "__new__", label: "+ Add new account" },
+  ];
 
   return (
-    <div className="px-8 py-10">
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="max-w-[800px] mx-auto bg-surface p-8 rounded-2xl border border-border grid grid-cols-2 gap-5"
-    >
-      {/* Header */}
-      <div className="col-span-2 mb-2 pb-4 border-b border-border">
-        <div className="flex items-start justify-between gap-4">
-          <h2 className="text-2xl font-semibold text-ink-primary">Log New Trade</h2>
-          <div className="flex items-center gap-2 pt-0.5">
-            {cancelConfirming ? (
-              <>
-                <span className="text-xs text-ink-secondary">Discard changes?</span>
+    <div className="px-4 py-8 sm:px-8">
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="max-w-5xl mx-auto bg-surface rounded-2xl border border-border overflow-hidden flex flex-col"
+      >
+        {/* Header */}
+        <div className="px-8 py-6 border-b border-border">
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-xl font-semibold text-ink-primary">Log New Trade</h2>
+            <div className="flex items-center gap-2">
+              {cancelConfirming ? (
+                <>
+                  <span className="text-xs text-ink-secondary">Discard changes?</span>
+                  <button
+                    type="button"
+                    className="px-2.5 py-1 bg-ink-primary text-white rounded-md text-xs font-medium cursor-pointer hover:bg-ink-secondary transition-colors duration-150"
+                    onClick={() => navigate(-1)}
+                  >
+                    Discard
+                  </button>
+                  <button
+                    type="button"
+                    className="px-2.5 py-1 bg-transparent text-ink-secondary border border-border rounded-md text-xs font-medium cursor-pointer hover:bg-surface-alt transition-colors duration-150"
+                    onClick={() => setCancelConfirming(false)}
+                  >
+                    Keep editing
+                  </button>
+                </>
+              ) : (
                 <button
                   type="button"
-                  className="px-2.5 py-1 bg-red-500 text-white rounded-md text-xs font-medium cursor-pointer hover:bg-red-600 transition-colors duration-100"
-                  onClick={() => navigate(-1)}
+                  className="px-3.5 py-1.5 bg-transparent text-ink-secondary border border-border rounded-md text-sm cursor-pointer hover:bg-surface-alt transition-colors duration-150"
+                  onClick={handleCancel}
                 >
-                  Discard
+                  Cancel
                 </button>
-                <button
-                  type="button"
-                  className="px-2.5 py-1 bg-transparent text-ink-secondary border border-border rounded-md text-xs font-medium cursor-pointer hover:bg-surface-alt transition-colors duration-100"
-                  onClick={() => setCancelConfirming(false)}
-                >
-                  Keep editing
-                </button>
-              </>
-            ) : (
-              <button
-                type="button"
-                className="px-3.5 py-1.5 bg-transparent text-ink-secondary border border-border rounded-md text-sm cursor-pointer hover:bg-surface-alt transition-colors duration-100"
-                onClick={handleCancel}
-              >
-                Cancel
-              </button>
-            )}
+              )}
+            </div>
           </div>
+          {addEntryMutation.error && (
+            <p className="mt-4 text-sm text-ink-secondary bg-surface-alt border border-border rounded-lg px-3 py-2">
+              {addEntryMutation.error.message}
+            </p>
+          )}
         </div>
-        {addEntryMutation.error && (
-          <p className="mt-3 text-sm text-ink-secondary bg-surface-alt border border-border rounded-md px-3 py-2">
-            {addEntryMutation.error.message}
-          </p>
-        )}
-      </div>
 
-      {/* Account */}
-      <div>
-        <label className={labelStyles}>Trading Account</label>
-        {accounts && accounts.length === 0 ? (
+        {/* Body */}
+        <div className="flex flex-col lg:flex-row">
+
+          {/* Left: Trade Details */}
+          <div className="flex-1 min-w-0 px-8 py-7 flex flex-col gap-7">
+
+            {/* Session */}
+            <div>
+              <SectionHeader label="Session" />
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label className={labelStyles} htmlFor="accountId">Trading Account</label>
+                  {accounts && accounts.length === 0 ? (
+                    <button
+                      type="button"
+                      onClick={() => setAddingAccount(true)}
+                      className="text-sm text-ink-muted hover:text-ink-primary transition-colors duration-150 cursor-pointer"
+                    >
+                      New Account
+                    </button>
+                  ) : (
+                    <Controller
+                      control={control}
+                      name="accountId"
+                      rules={{ required: "Selecting a trading account is required." }}
+                      render={({ field }) => (
+                        <Select
+                          id="accountId"
+                          name={field.name}
+                          value={field.value ?? ""}
+                          onChange={(val) => {
+                            if (val === "__new__") {
+                              setAddingAccount(true);
+                            } else {
+                              field.onChange(val);
+                            }
+                          }}
+                          onBlur={field.onBlur}
+                          options={accountOptions}
+                          placeholder="Select account"
+                        />
+                      )}
+                    />
+                  )}
+                  {errors.accountId && (
+                    <span className={errorStyles}>{errors.accountId.message}</span>
+                  )}
+                </div>
+
+                <div>
+                  <label className={labelStyles} htmlFor="result">Result</label>
+                  <Controller
+                    control={control}
+                    name="result"
+                    rules={{ required: "Selecting a result is required." }}
+                    render={({ field }) => (
+                      <Select
+                        id="result"
+                        name={field.name}
+                        value={field.value ?? ""}
+                        onChange={field.onChange}
+                        onBlur={field.onBlur}
+                        options={[
+                          { value: "Win", label: "Win" },
+                          { value: "Loss", label: "Loss" },
+                          { value: "Break Even", label: "Break Even" },
+                        ]}
+                        placeholder="Select result"
+                      />
+                    )}
+                  />
+                  {errors.result && (
+                    <span className={errorStyles}>{errors.result.message}</span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Instrument */}
+            <div>
+              <SectionHeader label="Instrument" />
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <div>
+                  <label className={labelStyles} htmlFor="contract">Contract</label>
+                  <Controller
+                    control={control}
+                    name="contract"
+                    rules={{ required: "Selecting a contract type is required." }}
+                    render={({ field }) => (
+                      <Select
+                        id="contract"
+                        name={field.name}
+                        value={field.value ?? ""}
+                        onChange={field.onChange}
+                        onBlur={field.onBlur}
+                        options={[
+                          { value: "NQ", label: "NQ" },
+                          { value: "MNQ", label: "MNQ" },
+                          { value: "ES", label: "ES" },
+                          { value: "MES", label: "MES" },
+                        ]}
+                        placeholder="Select"
+                      />
+                    )}
+                  />
+                  {errors.contract && (
+                    <span className={errorStyles}>{errors.contract.message}</span>
+                  )}
+                </div>
+
+                <div>
+                  <label className={labelStyles} htmlFor="direction">Direction</label>
+                  <Controller
+                    control={control}
+                    name="direction"
+                    rules={{ required: "Selecting a direction is required." }}
+                    render={({ field }) => (
+                      <Select
+                        id="direction"
+                        name={field.name}
+                        value={field.value ?? ""}
+                        onChange={field.onChange}
+                        onBlur={field.onBlur}
+                        options={[
+                          { value: "Long", label: "Long" },
+                          { value: "Short", label: "Short" },
+                        ]}
+                        placeholder="Select"
+                      />
+                    )}
+                  />
+                  {errors.direction && (
+                    <span className={errorStyles}>{errors.direction.message}</span>
+                  )}
+                </div>
+
+                <div>
+                  <label className={labelStyles} htmlFor="contracts">Contracts</label>
+                  <input
+                    id="contracts"
+                    type="number"
+                    step="1"
+                    min="1"
+                    className={inputStyles}
+                    {...register("contracts", {
+                      required: "The number of contracts is required.",
+                      min: { value: 1, message: "Contracts must be at least 1" },
+                      valueAsNumber: true,
+                    })}
+                  />
+                  {errors.contracts && (
+                    <span className={errorStyles}>{errors.contracts.message}</span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Price Levels */}
+            <div>
+              <SectionHeader label="Price Levels" />
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label className={labelStyles} htmlFor="entryPrice">Entry Price</label>
+                  <input
+                    id="entryPrice"
+                    type="number"
+                    step="0.01"
+                    className={inputStyles}
+                    {...register("entryPrice", {
+                      required: "Entry price is required",
+                      min: { value: 4000, message: "Entry price must be greater than 4,000." },
+                      max: { value: 50000, message: "Entry price must be less than 50,000." },
+                      valueAsNumber: true,
+                    })}
+                  />
+                  {errors.entryPrice && (
+                    <span className={errorStyles}>{errors.entryPrice.message}</span>
+                  )}
+                </div>
+
+                <div>
+                  <label className={labelStyles} htmlFor="exitPrice">Exit Price</label>
+                  <input
+                    id="exitPrice"
+                    type="number"
+                    step="0.01"
+                    className={inputStyles}
+                    {...register("exitPrice", {
+                      required: "Exit price is required",
+                      min: { value: 4000, message: "Exit price must be greater than 4,000." },
+                      max: { value: 50000, message: "Exit price must be less than 50,000." },
+                      valueAsNumber: true,
+                    })}
+                  />
+                  {errors.exitPrice && (
+                    <span className={errorStyles}>{errors.exitPrice.message}</span>
+                  )}
+                </div>
+
+                <div>
+                  <label className={labelStyles} htmlFor="stopLoss">Stop Loss</label>
+                  <input
+                    id="stopLoss"
+                    type="number"
+                    step="0.01"
+                    className={inputStyles}
+                    {...register("stopLoss", {
+                      required: "Stop loss is required",
+                      min: { value: 4000, message: "Stop loss must be greater than 4,000." },
+                      max: { value: 50000, message: "Stop loss must be less than 50,000." },
+                      valueAsNumber: true,
+                    })}
+                  />
+                  {errors.stopLoss && (
+                    <span className={errorStyles}>{errors.stopLoss.message}</span>
+                  )}
+                </div>
+
+                <div>
+                  <label className={labelStyles} htmlFor="target">Target</label>
+                  <input
+                    id="target"
+                    type="number"
+                    step="0.01"
+                    className={inputStyles}
+                    {...register("target", {
+                      required: "Target is required",
+                      min: { value: 4000, message: "Target must be greater than 4,000." },
+                      max: { value: 50000, message: "Target must be less than 50,000." },
+                      valueAsNumber: true,
+                    })}
+                  />
+                  {errors.target && (
+                    <span className={errorStyles}>{errors.target.message}</span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Timing */}
+            <div>
+              <SectionHeader label="Timing" />
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label className={labelStyles} htmlFor="entryTime">Entry Time</label>
+                  <input
+                    id="entryTime"
+                    type="datetime-local"
+                    className={inputStyles}
+                    {...register("entryTime", { required: "Entry time is required" })}
+                  />
+                  {errors.entryTime && (
+                    <span className={errorStyles}>{errors.entryTime.message}</span>
+                  )}
+                </div>
+
+                <div>
+                  <label className={labelStyles} htmlFor="exitTime">Exit Time</label>
+                  <input
+                    id="exitTime"
+                    type="datetime-local"
+                    className={inputStyles}
+                    {...register("exitTime", { required: "Exit time is required" })}
+                  />
+                  {errors.exitTime && (
+                    <span className={errorStyles}>{errors.exitTime.message}</span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+          </div>
+
+          {/* Right: Notes Panel */}
+          <div className="lg:w-[400px] shrink-0 border-t border-border lg:border-t-0 lg:border-l bg-surface-alt px-6 py-7 flex flex-col gap-6">
+            <div className="flex-1 flex flex-col">
+              <label className={labelStyles}>Notes</label>
+              <TextEditor onChange={setNotes} />
+            </div>
+            <div>
+              <label className={labelStyles}>Images</label>
+              <ImageUpload onChange={setUploadedImages} maxImages={5} />
+            </div>
+          </div>
+
+        </div>
+
+        {/* Footer */}
+        <div className="px-8 py-5 border-t border-border">
           <button
-            type="button"
-            onClick={() => setAddingAccount(true)}
-            className="text-sm text-ink-muted hover:text-ink-primary transition-colors duration-150 cursor-pointer"
+            type="submit"
+            className="w-full py-2.5 bg-accent text-white rounded-lg text-sm font-semibold cursor-pointer transition-colors duration-150 hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={addEntryMutation.isPending}
           >
-            New Account
+            {addEntryMutation.isPending ? "Submitting..." : "Log Trade"}
           </button>
-        ) : (
-          <select
-            className={selectStyles}
-            {...accountRest}
-            value={selectedAccountId}
-            onChange={(e) => {
-              if (e.target.value === "__new__") {
-                setAddingAccount(true);
-                setSelectedAccountId("");
-                setValue("accountId", "", { shouldValidate: false });
-              } else {
-                setSelectedAccountId(e.target.value);
-                rhfAccountOnChange(e);
-              }
-            }}
-          >
-            <option value="">Select a trading account</option>
-            {accounts?.map((account) => (
-              <option value={account._id} key={account._id}>{account.accountName}</option>
-            ))}
-            <option value="__new__">Add new account</option>
-          </select>
-        )}
-        {errors.accountId && (
-          <span className={errorStyles}>{errors.accountId.message}</span>
-        )}
-      </div>
+        </div>
+      </form>
 
       {addingAccount && (
         <AccountModal
           onClose={() => setAddingAccount(false)}
-          onSuccess={(acc) => { setSelectedAccountId(acc._id); setValue("accountId", acc._id); }}
+          onSuccess={(acc) => setValue("accountId", acc._id)}
         />
       )}
-
-      {/* Result */}
-      <div>
-        <label className={labelStyles}>Result</label>
-        <select
-          className={selectStyles}
-          {...register("result", {
-            required: "Selecting a result is required.",
-          })}
-        >
-          <option value="">Select a result</option>
-          <option value="Win">Win</option>
-          <option value="Loss">Loss</option>
-          <option value="Break Even">Break Even</option>
-        </select>
-        {errors.result && (
-          <span className={errorStyles}>{errors.result.message}</span>
-        )}
-      </div>
-
-      {/* Contract */}
-      <div>
-        <label className={labelStyles}>Contract</label>
-        <select
-          className={selectStyles}
-          {...register("contract", {
-            required: "Selecting a contract type is required.",
-          })}
-        >
-          <option value="">Select a contract</option>
-          <option value="NQ">NQ</option>
-          <option value="MNQ">MNQ</option>
-          <option value="ES">ES</option>
-          <option value="MES">MES</option>
-        </select>
-        {errors.contract && (
-          <span className={errorStyles}>{errors.contract.message}</span>
-        )}
-      </div>
-
-      {/* Direction */}
-      <div>
-        <label className={labelStyles}>Direction</label>
-        <select
-          className={selectStyles}
-          {...register("direction", {
-            required: "Selecting a direction is required.",
-          })}
-        >
-          <option value="">Select a direction</option>
-          <option value="Long">Long</option>
-          <option value="Short">Short</option>
-        </select>
-        {errors.direction && (
-          <span className={errorStyles}>{errors.direction.message}</span>
-        )}
-      </div>
-
-      {/* Contracts */}
-      <div>
-        <label className={labelStyles}>Number of Contracts</label>
-        <input
-          type="number"
-          step="1"
-          min="1"
-          className={inputStyles}
-          {...register("contracts", {
-            required: "The number of contracts is required.",
-            min: { value: 1, message: "Contracts must be at least 1" },
-            valueAsNumber: true,
-          })}
-        />
-        {errors.contracts && (
-          <span className={errorStyles}>{errors.contracts.message}</span>
-        )}
-      </div>
-
-      {/* Entry Price */}
-      <div>
-        <label className={labelStyles}>Entry Price</label>
-        <input
-          type="number"
-          step="0.01"
-          className={inputStyles}
-          {...register("entryPrice", {
-            required: "Entry price is required",
-            min: { value: 4000, message: "Entry price must be greater than 4,000." },
-            max: { value: 50000, message: "Entry price must be less than 50,000." },
-            valueAsNumber: true,
-          })}
-        />
-        {errors.entryPrice && (
-          <span className={errorStyles}>{errors.entryPrice.message}</span>
-        )}
-      </div>
-
-      {/* Exit Price */}
-      <div>
-        <label className={labelStyles}>Exit Price</label>
-        <input
-          type="number"
-          step="0.01"
-          className={inputStyles}
-          {...register("exitPrice", {
-            required: "Exit price is required",
-            min: { value: 4000, message: "Exit price must be greater than 4,000." },
-            max: { value: 50000, message: "Exit price must be less than 50,000." },
-            valueAsNumber: true,
-          })}
-        />
-        {errors.exitPrice && (
-          <span className={errorStyles}>{errors.exitPrice.message}</span>
-        )}
-      </div>
-
-      {/* Stop Loss */}
-      <div>
-        <label className={labelStyles}>Stop Loss</label>
-        <input
-          type="number"
-          step="0.01"
-          className={inputStyles}
-          {...register("stopLoss", {
-            required: "Stop loss is required",
-            min: { value: 4000, message: "Stop loss must be greater than 4,000." },
-            max: { value: 50000, message: "Stop loss must be less than 50,000." },
-            valueAsNumber: true,
-          })}
-        />
-        {errors.stopLoss && (
-          <span className={errorStyles}>{errors.stopLoss.message}</span>
-        )}
-      </div>
-
-      {/* Target */}
-      <div>
-        <label className={labelStyles}>Target</label>
-        <input
-          type="number"
-          step="0.01"
-          className={inputStyles}
-          {...register("target", {
-            required: "Target is required",
-            min: { value: 4000, message: "Target must be greater than 4,000." },
-            max: { value: 50000, message: "Target must be less than 50,000." },
-            valueAsNumber: true,
-          })}
-        />
-        {errors.target && (
-          <span className={errorStyles}>{errors.target.message}</span>
-        )}
-      </div>
-
-      {/* Entry Time */}
-      <div>
-        <label className={labelStyles}>Entry Time</label>
-        <input
-          type="datetime-local"
-          className={inputStyles}
-          {...register("entryTime", { required: "Entry time is required" })}
-        />
-        {errors.entryTime && (
-          <span className={errorStyles}>{errors.entryTime.message}</span>
-        )}
-      </div>
-
-      {/* Exit Time */}
-      <div>
-        <label className={labelStyles}>Exit Time</label>
-        <input
-          type="datetime-local"
-          className={inputStyles}
-          {...register("exitTime", { required: "Exit time is required" })}
-        />
-        {errors.exitTime && (
-          <span className={errorStyles}>{errors.exitTime.message}</span>
-        )}
-      </div>
-
-      {/* Notes */}
-      <div className="col-span-2">
-        <label className={labelStyles}>Notes</label>
-        <TextEditor onChange={setNotes} />
-      </div>
-
-      {/* Images */}
-      <div className="col-span-2">
-        <label className={labelStyles}>Images</label>
-        <ImageUpload onChange={setUploadedImages} maxImages={5} />
-      </div>
-
-      {/* Submit */}
-      <button
-        type="submit"
-        className="col-span-2 w-full py-3 bg-accent text-white rounded-lg text-sm font-semibold cursor-pointer transition-colors duration-150 hover:bg-accent-hover mt-2 disabled:opacity-50 disabled:cursor-not-allowed"
-        disabled={addEntryMutation.isPending}
-      >
-        {addEntryMutation.isPending ? "Submitting..." : "Submit"}
-      </button>
-    </form>
     </div>
   );
 };

--- a/frontend/src/components/Select.tsx
+++ b/frontend/src/components/Select.tsx
@@ -1,0 +1,206 @@
+import { useState, useRef, useEffect } from "react";
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectProps {
+  options: SelectOption[];
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+  placeholder?: string;
+  id?: string;
+  name?: string;
+  disabled?: boolean;
+}
+
+const Select = ({
+  options,
+  value,
+  onChange,
+  onBlur,
+  placeholder = "Select...",
+  id,
+  name,
+  disabled = false,
+}: SelectProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const selectedOption = options.find((o) => o.value === value);
+  const listboxId = `${id ?? "select"}-listbox`;
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+        onBlur?.();
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [isOpen, onBlur]);
+
+  useEffect(() => {
+    if (!isOpen || highlightedIndex < 0 || !listRef.current) return;
+    const item = listRef.current.children[highlightedIndex] as HTMLElement;
+    item?.scrollIntoView({ block: "nearest" });
+  }, [highlightedIndex, isOpen]);
+
+  const openDropdown = () => {
+    if (disabled) return;
+    const currentIdx = options.findIndex((o) => o.value === value);
+    setHighlightedIndex(currentIdx >= 0 ? currentIdx : 0);
+    setIsOpen(true);
+  };
+
+  const closeDropdown = () => {
+    setIsOpen(false);
+    setHighlightedIndex(-1);
+  };
+
+  const selectOption = (optionValue: string) => {
+    onChange(optionValue);
+    closeDropdown();
+    triggerRef.current?.focus();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (disabled) return;
+    switch (e.key) {
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        if (isOpen) {
+          if (highlightedIndex >= 0) selectOption(options[highlightedIndex].value);
+        } else {
+          openDropdown();
+        }
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        if (!isOpen) {
+          openDropdown();
+        } else {
+          setHighlightedIndex((i) => Math.min(i + 1, options.length - 1));
+        }
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        if (!isOpen) {
+          openDropdown();
+        } else {
+          setHighlightedIndex((i) => Math.max(i - 1, 0));
+        }
+        break;
+      case "Escape":
+        if (isOpen) {
+          e.stopPropagation();
+          closeDropdown();
+          onBlur?.();
+        }
+        break;
+      case "Tab":
+        if (isOpen) {
+          closeDropdown();
+          onBlur?.();
+        }
+        break;
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        id={id}
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? listboxId : undefined}
+        aria-label={name}
+        disabled={disabled}
+        onClick={() => (isOpen ? closeDropdown() : openDropdown())}
+        onKeyDown={handleKeyDown}
+        onBlur={(e) => {
+          if (!containerRef.current?.contains(e.relatedTarget as Node)) {
+            closeDropdown();
+            onBlur?.();
+          }
+        }}
+        className={[
+          "w-full flex items-center justify-between gap-2 px-3.5 py-2.5 bg-surface",
+          "border rounded-lg text-sm text-left outline-none transition-colors duration-150",
+          disabled
+            ? "opacity-50 cursor-not-allowed border-border"
+            : "cursor-pointer border-border hover:border-ink-muted",
+          isOpen ? "border-accent ring-2 ring-accent-light" : "",
+          value ? "text-ink-primary" : "text-ink-muted",
+        ].join(" ")}
+      >
+        <span className="truncate">{selectedOption?.label ?? placeholder}</span>
+        <svg
+          className={`h-4 w-4 text-ink-muted shrink-0 transition-transform duration-150 ${isOpen ? "rotate-180" : ""}`}
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M4 6l4 4 4-4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          tabIndex={-1}
+          className="absolute z-50 top-full left-0 right-0 mt-1.5 bg-surface border border-border rounded-lg shadow-dropdown py-1 max-h-56 overflow-y-auto"
+        >
+          {options.map((option, index) => {
+            const isSelected = option.value === value;
+            const isHighlighted = index === highlightedIndex;
+            return (
+              <li
+                key={option.value}
+                role="option"
+                aria-selected={isSelected}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  selectOption(option.value);
+                }}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                className={[
+                  "px-3.5 py-2.5 text-sm cursor-pointer select-none transition-colors duration-100",
+                  isSelected
+                    ? "text-accent font-medium bg-accent-light"
+                    : isHighlighted
+                    ? "bg-surface-alt text-ink-primary"
+                    : "text-ink-primary",
+                ].join(" ")}
+              >
+                {option.label}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Select;

--- a/frontend/src/components/StatsDashboard.tsx
+++ b/frontend/src/components/StatsDashboard.tsx
@@ -92,6 +92,12 @@ const CardSkeleton = () => (
   </div>
 );
 
+const ChevronDownIcon = () => (
+  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="shrink-0">
+    <path d="M2 3.5L5 6.5L8 3.5" />
+  </svg>
+);
+
 const StatsDashboard = () => {
   const { user } = useAuth();
   const [modalOpen, setModalOpen] = useState(false);
@@ -164,28 +170,34 @@ const StatsDashboard = () => {
         {accounts.length === 0 ? (
           <button
             onClick={() => setModalOpen(true)}
-            className="text-sm text-ink-muted hover:text-ink-primary transition-colors duration-150 cursor-pointer whitespace-nowrap"
+            className="flex items-center gap-1 text-sm font-medium text-ink-muted hover:text-ink-primary transition-colors duration-150 cursor-pointer whitespace-nowrap"
           >
             New Account
+            <ChevronDownIcon />
           </button>
         ) : (
-          <select
-            aria-label="Select trading account"
-            value={selectedAccountId || accounts[0]._id}
-            className="text-sm text-ink-secondary border border-border rounded-lg px-3 py-1.5 bg-surface cursor-pointer outline-none focus:border-accent transition-colors duration-150"
-            onChange={(e) => {
-              if (e.target.value === "__new__") {
-                setModalOpen(true);
-              } else {
-                setSelectedAccountId(e.target.value);
-              }
-            }}
-          >
-            {accounts.map((account) => (
-              <option key={account._id} value={account._id}>{account.accountName}</option>
-            ))}
-            <option value="__new__">New account</option>
-          </select>
+          <div className="relative flex items-center group">
+            <select
+              aria-label="Select trading account"
+              value={selectedAccountId || accounts[0]._id}
+              className="appearance-none text-sm font-medium text-ink-muted group-hover:text-ink-primary bg-transparent border-0 outline-none cursor-pointer transition-colors duration-150 whitespace-nowrap pr-3"
+              onChange={(e) => {
+                if (e.target.value === "__new__") {
+                  setModalOpen(true);
+                } else {
+                  setSelectedAccountId(e.target.value);
+                }
+              }}
+            >
+              {accounts.map((account) => (
+                <option key={account._id} value={account._id}>{account.accountName}</option>
+              ))}
+              <option value="__new__">New account</option>
+            </select>
+            <span className="absolute right-0 pointer-events-none text-ink-muted group-hover:text-ink-primary transition-colors duration-150">
+              <ChevronDownIcon />
+            </span>
+          </div>
         )}
       </div>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -89,6 +89,8 @@
 
 .ProseMirror {
   min-height: 300px;
+  max-height: 300px;
+  overflow-y: auto;
   padding: 10px;
   background: var(--color-surface-alt);
   color: var(--color-ink-primary);

--- a/frontend/src/utils/styleConstants.ts
+++ b/frontend/src/utils/styleConstants.ts
@@ -1,7 +1,8 @@
 // Form field styles (NewTradeEntry, NewNoTradeEntry)
 export const formInputStyles =
-  "w-full px-3.5 py-2.5 border border-border rounded-lg text-sm text-ink-primary outline-none transition-colors focus:border-accent font-inherit";
-export const formSelectStyles = `${formInputStyles} cursor-pointer`;
+  "w-full px-3.5 py-2.5 bg-surface border border-border rounded-lg text-sm text-ink-primary outline-none transition-colors focus:border-accent focus:ring-2 focus:ring-accent/10 font-inherit";
+export const formSelectStyles =
+  "w-full appearance-none px-3.5 py-2.5 pr-10 bg-surface border border-border rounded-lg text-sm text-ink-primary outline-none transition-colors hover:border-ink-muted focus:border-accent focus:ring-2 focus:ring-accent/10 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed font-inherit";
 export const accountSelectStyles =
   "w-full text-sm text-ink-muted bg-transparent border-0 outline-none cursor-pointer hover:text-ink-primary transition-colors duration-150 font-inherit";
 export const formLabelStyles =

--- a/frontend/src/utils/styleConstants.ts
+++ b/frontend/src/utils/styleConstants.ts
@@ -2,6 +2,8 @@
 export const formInputStyles =
   "w-full px-3.5 py-2.5 border border-border rounded-lg text-sm text-ink-primary outline-none transition-colors focus:border-accent font-inherit";
 export const formSelectStyles = `${formInputStyles} cursor-pointer`;
+export const accountSelectStyles =
+  "w-full text-sm text-ink-muted bg-transparent border-0 outline-none cursor-pointer hover:text-ink-primary transition-colors duration-150 font-inherit";
 export const formLabelStyles =
   "block text-sm font-medium text-ink-secondary mb-1.5";
 export const formErrorStyles = "block text-xs text-pnl-negative mt-1";


### PR DESCRIPTION
## Summary

- Add account creation modal so users can create a trading account inline without leaving the entry form
- Redesign NewTradeEntry and NewNoTradeEntry with a two-panel layout — trade details on the left in semantic sections (Session, Instrument, Price Levels, Timing), notes and images in a visually distinct panel on the right
- Replace all native `<select>` elements with a fully styled custom Select component that controls the dropdown panel, option states, keyboard navigation, and focus ring
- Auto-select newly created accounts across all dropdowns after modal submission
- Redesign journal earlier entries as a document list with hover states

## Test plan

- Create a new trading account via the modal from inside the entry form — verify it auto-selects in the dropdown
- Submit a trade entry and no-trade entry — verify data saves correctly and navigation goes to the detail view
- Open each custom dropdown and verify keyboard navigation: Arrow up/down, Enter to select, Escape to close, Tab to blur
- Trigger validation errors on all required select fields — verify error messages appear
- Resize to mobile — verify both forms stack to a single column layout
- Open the account modal and cancel — verify the account field stays empty