### PR TITLE
refactor: colocate query key factories with the API module

### DIFF
--- a/deepen-queue.md
+++ b/deepen-queue.md
@@ -3,9 +3,3 @@
 Architectural flags queued by `/cleanup` passes. Review with `/deepen`.
 
 ---
-
-## 2026-05-21 — feat/issue-9-account-scoped-stats
-
-**File:** `frontend/src/components/StatsDashboard.tsx:110–125`
-**Problem type:** Low locality
-**Description:** Query cache keys for the stats and trades queries (`["stats", effectiveAccountId]`, `["trades", effectiveAccountId]`) are defined inline in the component. Any code that needs to invalidate these keys (e.g., after a trade mutation) must know the key shape, coupling callers to implementation details. Consider colocating key factories with the API functions in `api.ts` or a dedicated query-keys file.

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -1,0 +1,8 @@
+export const queryKeys = {
+  accounts: () => ["allAccounts"] as const,
+  allEntries: () => ["allEntries"] as const,
+  tradeEntry: (id: string) => ["entry", id] as const,
+  noTradeEntry: (id: string) => ["noTradeEntry", id] as const,
+  stats: (accountId?: string) => ["stats", accountId] as const,
+  tradeEntries: (accountId?: string) => ["trades", accountId] as const,
+};

--- a/frontend/src/components/AccountModal.tsx
+++ b/frontend/src/components/AccountModal.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createAccount } from "../api/api";
+import { queryKeys } from "../api/queryKeys";
 import { Account, CreateAccountData } from "../types/account.types";
 import {
   formInputStyles as inputStyles,
@@ -23,7 +24,7 @@ const AccountModal = ({ onClose, onSuccess }: AccountModalProps) => {
   const mutation = useMutation({
     mutationFn: createAccount,
     onSuccess: async (account) => {
-      await queryClient.invalidateQueries({ queryKey: ["allAccounts"] });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.accounts() });
       onSuccess?.(account);
       onClose();
     },

--- a/frontend/src/components/NewNoTradeEntry.tsx
+++ b/frontend/src/components/NewNoTradeEntry.tsx
@@ -1,5 +1,6 @@
 import { useForm, Controller } from "react-hook-form";
 import { createNoTradeEntry } from "../api/api";
+import { queryKeys } from "../api/queryKeys";
 import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import TextEditor from "./TextEditor.js";
@@ -55,8 +56,8 @@ const NewNoTradeEntry = () => {
         console.error("No ID returned from the server.");
         return;
       }
-      queryClient.setQueryData(["noTradeEntry", data._id], data);
-      queryClient.invalidateQueries({ queryKey: ["allEntries"] });
+      queryClient.setQueryData(queryKeys.noTradeEntry(data._id), data);
+      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
       navigate(`/dashboard/no-trade-entries/${data._id}`);
       reset();
     },
@@ -70,7 +71,7 @@ const NewNoTradeEntry = () => {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["allAccounts"],
+    queryKey: queryKeys.accounts(),
     queryFn: getAccounts,
   });
 

--- a/frontend/src/components/NewTradeEntry.tsx
+++ b/frontend/src/components/NewTradeEntry.tsx
@@ -1,5 +1,6 @@
 import { useForm, Controller } from "react-hook-form";
 import { createTradeEntry } from "../api/api";
+import { queryKeys } from "../api/queryKeys";
 import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { CreateTradeEntryData } from "../types/tradeEntry.types";
@@ -47,8 +48,8 @@ const NewEntry = () => {
         console.error("No ID returned from the server.");
         return;
       }
-      queryClient.setQueryData(["entry", data._id], data);
-      queryClient.invalidateQueries({ queryKey: ["allEntries"] });
+      queryClient.setQueryData(queryKeys.tradeEntry(data._id), data);
+      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
       navigate(`/dashboard/trade-entries/${data._id}`);
       reset();
     },
@@ -62,7 +63,7 @@ const NewEntry = () => {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["allAccounts"],
+    queryKey: queryKeys.accounts(),
     queryFn: getAccounts,
   });
 

--- a/frontend/src/components/NoTradeEntryDetail.tsx
+++ b/frontend/src/components/NoTradeEntryDetail.tsx
@@ -4,6 +4,7 @@ import {
   getNoTradeEntry,
   updateNoTradeEntry,
 } from "../api/api.js";
+import { queryKeys } from "../api/queryKeys";
 import { useParams, useNavigate } from "react-router-dom";
 import { useState, useRef, useEffect, KeyboardEvent, ChangeEvent } from "react";
 import TextEditor from "./TextEditor.js";
@@ -51,7 +52,7 @@ const NoTradeEntryDetail = () => {
     isLoading,
     error,
   } = useQuery<NoTradeEntry>({
-    queryKey: ["noTradeEntry", id],
+    queryKey: queryKeys.noTradeEntry(id!),
     queryFn: () => {
       if (!id) throw new Error("No id provided");
       return getNoTradeEntry(id);
@@ -60,15 +61,15 @@ const NoTradeEntryDetail = () => {
   });
 
   const { data: accounts } = useQuery({
-    queryKey: ["allAccounts"],
+    queryKey: queryKeys.accounts(),
     queryFn: getAccounts,
   });
 
   const updateMutation = useMutation({
     mutationFn: updateNoTradeEntry,
     onSuccess: (data) => {
-      queryClient.setQueryData(["noTradeEntry", id], data);
-      queryClient.invalidateQueries({ queryKey: ["allEntries"] });
+      queryClient.setQueryData(queryKeys.noTradeEntry(id!), data);
+      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
       setSaveStatus("saved");
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => setSaveStatus("idle"), 2000);
@@ -81,7 +82,7 @@ const NoTradeEntryDetail = () => {
   const deleteMutation = useMutation({
     mutationFn: deleteNoTradeEntry,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["allEntries"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
       navigate("/dashboard");
     },
     onError: () => {

--- a/frontend/src/components/StatsDashboard.tsx
+++ b/frontend/src/components/StatsDashboard.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { getStats, getTradeEntries, getAccounts } from "../api/api";
+import { queryKeys } from "../api/queryKeys";
 import { Stats, TradeEntry } from "../types/tradeEntry.types";
 import TradeCalendar from "./TradeCalendar";
 import { Link } from "react-router-dom";
@@ -105,7 +106,7 @@ const StatsDashboard = () => {
   const [selectedAccountId, setSelectedAccountId] = useState("");
 
   const { data: accounts = [], isLoading: accountsLoading } = useQuery({
-    queryKey: ["allAccounts"],
+    queryKey: queryKeys.accounts(),
     queryFn: getAccounts,
   });
 
@@ -116,13 +117,13 @@ const StatsDashboard = () => {
     isLoading: statsLoading,
     error,
   } = useQuery<Stats>({
-    queryKey: ["stats", effectiveAccountId],
+    queryKey: queryKeys.stats(effectiveAccountId),
     queryFn: () => getStats(effectiveAccountId),
     enabled: !!effectiveAccountId,
   });
 
   const { data: trades = [], isLoading: tradesLoading } = useQuery({
-    queryKey: ["trades", effectiveAccountId],
+    queryKey: queryKeys.tradeEntries(effectiveAccountId),
     queryFn: () => getTradeEntries(effectiveAccountId),
     enabled: !!effectiveAccountId,
   });

--- a/frontend/src/components/TradeEntryDetail.tsx
+++ b/frontend/src/components/TradeEntryDetail.tsx
@@ -4,6 +4,7 @@ import {
   getTradeEntry,
   updateTradeEntry,
 } from "../api/api.js";
+import { queryKeys } from "../api/queryKeys";
 import { useParams, useNavigate } from "react-router-dom";
 import { useState, useRef, useEffect, ChangeEvent, KeyboardEvent } from "react";
 import TextEditor from "./TextEditor.js";
@@ -51,7 +52,7 @@ const TradeDetail = () => {
     isLoading,
     error,
   } = useQuery<TradeEntry>({
-    queryKey: ["entry", id],
+    queryKey: queryKeys.tradeEntry(id!),
     queryFn: () => {
       if (!id) throw new Error("No id provided");
       return getTradeEntry(id);
@@ -60,15 +61,15 @@ const TradeDetail = () => {
   });
 
   const { data: accounts } = useQuery({
-    queryKey: ["allAccounts"],
+    queryKey: queryKeys.accounts(),
     queryFn: getAccounts,
   });
 
   const updateTradeMutation = useMutation({
     mutationFn: updateTradeEntry,
     onSuccess: (data) => {
-      queryClient.setQueryData(["entry", id], data);
-      queryClient.invalidateQueries({ queryKey: ["allEntries"] });
+      queryClient.setQueryData(queryKeys.tradeEntry(id!), data);
+      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
       setSaveStatus("saved");
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => setSaveStatus("idle"), 2000);
@@ -81,7 +82,7 @@ const TradeDetail = () => {
   const deleteMutation = useMutation({
     mutationFn: deleteTradeEntry,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["allEntries"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
       navigate("/dashboard");
     },
     onError: () => {

--- a/frontend/src/pages/JournalPage.tsx
+++ b/frontend/src/pages/JournalPage.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { getTradeEntries, getNoTradeEntries, getAccounts } from "../api/api";
+import { queryKeys } from "../api/queryKeys";
 import AccountModal from "../components/AccountModal";
 import { Link, useNavigate } from "react-router-dom";
 import { useState, useRef, useEffect } from "react";
@@ -295,12 +296,12 @@ const JournalPage = () => {
   }, []);
 
   const { data: accounts = [], isLoading: accountsLoading } = useQuery({
-    queryKey: ["allAccounts"],
+    queryKey: queryKeys.accounts(),
     queryFn: getAccounts,
   });
 
   const { data: allEntries = [], isLoading } = useQuery<SidebarEntry[]>({
-    queryKey: ["allEntries"],
+    queryKey: queryKeys.allEntries(),
     queryFn: async () => {
       const [tradeEntries, noTradeEntries] = await Promise.all([
         getTradeEntries(),


### PR DESCRIPTION
## Summary
- Adds `frontend/src/api/queryKeys.ts` with a single `queryKeys` factory object covering all 6 key shapes used across the app
- Replaces 18 inline React Query key string literals across 7 files with typed factory calls
- Clears the `deepen-queue.md` entry flagged by the previous `/cleanup` pass

## Test plan
- [x] Playwright E2E tests pass locally (3/3)
- [x] TypeScript, lint, and Vitest all pass
- [ ] Verify cache invalidation still works after creating/deleting a trade entry
- [ ] Verify account switching on the stats dashboard still refreshes data

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)