### PR TITLE
refactor: extract useEntryDetail hook and shared SectionHeader

### DIFF
--- a/deepen-queue.md
+++ b/deepen-queue.md
@@ -3,3 +3,27 @@
 Architectural flags queued by `/cleanup` passes. Review with `/deepen`.
 
 ---
+
+## 2026-05-21 — deepen session (feat/query-key-factories)
+
+**Candidate:** #3 — Add error transformation to the API module
+**Files:** `frontend/src/api/api.ts`
+**Strength:** Worth exploring
+**Problem type:** Shallow module
+**Description:** 24 functions are direct axios pass-throughs with identical `console.error + re-throw` error handling. Callers still receive raw `AxiosError`; moving error handling to an axios response interceptor would give callers a stable typed interface.
+
+---
+
+**Candidate:** #4 — Extract `useNewEntryForm` hook
+**Files:** `frontend/src/components/NewTradeEntry.tsx`, `frontend/src/components/NewNoTradeEntry.tsx`
+**Strength:** Worth exploring
+**Problem type:** Parallel implementations
+**Description:** Form setup, account modal state, cancel confirmation flow, mutation wiring, and the `"__new__"` account sentinel are duplicated across both new-entry components; only the rendered fields differ.
+
+---
+
+**Candidate:** #5 — Extract `getPnl` from the trade entry controller
+**Files:** `backend/src/controllers/tradeEntry.controller.ts:71–86`
+**Strength:** Worth exploring
+**Problem type:** Low locality
+**Description:** Financial math (`getPnl`) lives inside the HTTP controller, making it unreusable and untestable without importing HTTP concerns. Move to `backend/src/lib/tradeCalc.ts` as a pure function.

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -28,6 +28,17 @@ const ImageUpload = ({ onChange, initialUrls, maxImages = 10 }: ImageUploadProps
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    if (!mountedRef.current) { mountedRef.current = true; return; }
+    const urls = items.filter((i) => i.url && !i.uploading && !i.error).map((i) => i.url!);
+    onChangeRef.current(urls);
+    return () => { mountedRef.current = false; };
+  }, [items]);
+
   const viewableItems = items.filter((i) => !i.uploading && !i.error);
 
   const closeLightbox = useCallback(() => setLightboxIndex(null), []);
@@ -55,10 +66,6 @@ const ImageUpload = ({ onChange, initialUrls, maxImages = 10 }: ImageUploadProps
     return () => window.removeEventListener("keydown", onKey);
   }, [lightboxIndex, closeLightbox, goNext, goPrev]);
 
-  const notifyParent = (updated: ImageItem[]) => {
-    onChange(updated.filter((i) => i.url).map((i) => i.url!));
-  };
-
   const processFiles = (files: FileList | null) => {
     if (!files) return;
 
@@ -77,14 +84,9 @@ const ImageUpload = ({ onChange, initialUrls, maxImages = 10 }: ImageUploadProps
 
       uploadImage(file)
         .then((url) => {
-          let updated: ImageItem[] = [];
-          setItems((prev) => {
-            updated = prev.map((i) =>
-              i.id === id ? { ...i, url, uploading: false } : i,
-            );
-            return updated;
-          });
-          notifyParent(updated);
+          setItems((prev) =>
+            prev.map((i) => i.id === id ? { ...i, url, uploading: false } : i),
+          );
         })
         .catch(() => {
           setItems((prev) =>
@@ -99,9 +101,7 @@ const ImageUpload = ({ onChange, initialUrls, maxImages = 10 }: ImageUploadProps
   };
 
   const remove = (id: string) => {
-    const updated = items.filter((i) => i.id !== id);
-    setItems(updated);
-    notifyParent(updated);
+    setItems((prev) => prev.filter((i) => i.id !== id));
   };
 
   const canAddMore = items.length < maxImages;

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -77,13 +77,14 @@ const ImageUpload = ({ onChange, initialUrls, maxImages = 10 }: ImageUploadProps
 
       uploadImage(file)
         .then((url) => {
+          let updated: ImageItem[] = [];
           setItems((prev) => {
-            const updated = prev.map((i) =>
+            updated = prev.map((i) =>
               i.id === id ? { ...i, url, uploading: false } : i,
             );
-            notifyParent(updated);
             return updated;
           });
+          notifyParent(updated);
         })
         .catch(() => {
           setItems((prev) =>
@@ -98,11 +99,9 @@ const ImageUpload = ({ onChange, initialUrls, maxImages = 10 }: ImageUploadProps
   };
 
   const remove = (id: string) => {
-    setItems((prev) => {
-      const updated = prev.filter((i) => i.id !== id);
-      notifyParent(updated);
-      return updated;
-    });
+    const updated = items.filter((i) => i.id !== id);
+    setItems(updated);
+    notifyParent(updated);
   };
 
   const canAddMore = items.length < maxImages;

--- a/frontend/src/components/NewNoTradeEntry.tsx
+++ b/frontend/src/components/NewNoTradeEntry.tsx
@@ -17,13 +17,7 @@ import {
 } from "../utils/styleConstants";
 import LoadingSpinner from "./LoadingSpinner";
 import ErrorState from "./ErrorState";
-
-const SectionHeader = ({ label }: { label: string }) => (
-  <div className="flex items-center gap-3 mb-4">
-    <span className="text-xs font-medium text-ink-muted tracking-[0.01em]">{label}</span>
-    <div className="flex-1 h-px bg-border" />
-  </div>
-);
+import SectionHeader from "./SectionHeader";
 
 const NewNoTradeEntry = () => {
   const {

--- a/frontend/src/components/NewTradeEntry.tsx
+++ b/frontend/src/components/NewTradeEntry.tsx
@@ -17,13 +17,7 @@ import LoadingSpinner from "./LoadingSpinner";
 import ErrorState from "./ErrorState";
 import ImageUpload from "./ImageUpload";
 import TextEditor from "./TextEditor";
-
-const SectionHeader = ({ label }: { label: string }) => (
-  <div className="flex items-center gap-3 mb-4">
-    <span className="text-xs font-medium text-ink-muted tracking-[0.01em]">{label}</span>
-    <div className="flex-1 h-px bg-border" />
-  </div>
-);
+import SectionHeader from "./SectionHeader";
 
 const NewEntry = () => {
   const {

--- a/frontend/src/components/NoTradeEntryDetail.tsx
+++ b/frontend/src/components/NoTradeEntryDetail.tsx
@@ -1,12 +1,11 @@
-import { useQueryClient, useMutation, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   deleteNoTradeEntry,
   getNoTradeEntry,
   updateNoTradeEntry,
 } from "../api/api.js";
 import { queryKeys } from "../api/queryKeys";
-import { useParams, useNavigate } from "react-router-dom";
-import { useState, useRef, useEffect, KeyboardEvent, ChangeEvent } from "react";
+import { useParams } from "react-router-dom";
 import TextEditor from "./TextEditor.js";
 import ImageUpload from "./ImageUpload";
 import { NoTradeEntry } from "../types/noTradeEntry.types.js";
@@ -20,77 +19,43 @@ import {
 import Select from "./Select";
 import LoadingSpinner from "./LoadingSpinner";
 import ErrorState from "./ErrorState";
-
-const SectionHeader = ({ label }: { label: string }) => (
-  <div className="flex items-center gap-3 mb-4">
-    <span className="text-xs font-medium text-ink-muted tracking-[0.01em]">{label}</span>
-    <div className="flex-1 h-px bg-border" />
-  </div>
-);
+import { useEntryDetail } from "../hooks/useEntryDetail";
+import SectionHeader from "./SectionHeader";
 
 const NoTradeEntryDetail = () => {
   const { id } = useParams<{ id: string }>();
-  const [activeField, setActiveField] = useState<string | null>(null);
-  const [tempValue, setTempValue] = useState("");
-  const [saveStatus, setSaveStatus] = useState<"idle" | "saved" | "error">("idle");
-  const [deleteConfirming, setDeleteConfirming] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const queryClient = useQueryClient();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    return () => {
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-      if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
-    };
-  }, []);
 
   const {
-    data: entry,
+    entry,
     isLoading,
     error,
-  } = useQuery<NoTradeEntry>({
+    saveStatus,
+    deleteConfirming,
+    deleteError,
+    handleSave,
+    handleDeleteClick,
+    handleDeleteCancel,
+    handleDeleteConfirm,
+    activate,
+    activeField,
+    sharedInputProps,
+    deleteMutation,
+    updateMutation,
+  } = useEntryDetail<NoTradeEntry>({
+    id: id!,
     queryKey: queryKeys.noTradeEntry(id!),
     queryFn: () => {
       if (!id) throw new Error("No id provided");
       return getNoTradeEntry(id);
     },
-    enabled: !!id,
+    updateFn: (payload) =>
+      updateNoTradeEntry(payload as Parameters<typeof updateNoTradeEntry>[0]),
+    deleteFn: deleteNoTradeEntry,
   });
 
   const { data: accounts } = useQuery({
     queryKey: queryKeys.accounts(),
     queryFn: getAccounts,
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: updateNoTradeEntry,
-    onSuccess: (data) => {
-      queryClient.setQueryData(queryKeys.noTradeEntry(id!), data);
-      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
-      setSaveStatus("saved");
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = setTimeout(() => setSaveStatus("idle"), 2000);
-    },
-    onError: () => {
-      setSaveStatus("error");
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: deleteNoTradeEntry,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
-      navigate("/dashboard");
-    },
-    onError: () => {
-      setDeleteConfirming(false);
-      setDeleteError("Could not delete. Try again.");
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = setTimeout(() => setDeleteError(null), 4000);
-    },
   });
 
   if (isLoading) return <LoadingSpinner message="Loading entry details..." />;
@@ -99,53 +64,6 @@ const NoTradeEntryDetail = () => {
 
   const { accountId, entryTime, notes } = entry;
   const formattedDate = entryTime && formatDateTime(entryTime);
-
-  const handleSave = (value = tempValue, field = activeField) => {
-    if (field) {
-      if (!id) throw new Error("No id provided");
-      updateMutation.mutate({ id, [field]: value });
-      setActiveField(null);
-      setTempValue("");
-    }
-  };
-
-  const handleDeleteClick = () => {
-    setDeleteConfirming(true);
-    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
-    deleteTimerRef.current = setTimeout(() => setDeleteConfirming(false), 4000);
-  };
-
-  const handleDeleteCancel = () => {
-    setDeleteConfirming(false);
-    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
-  };
-
-  const handleDeleteConfirm = () => {
-    if (!id) return;
-    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
-    deleteMutation.mutate(id);
-  };
-
-  const activate = (field: string, value: string) => {
-    setActiveField(field);
-    setTempValue(value);
-  };
-
-  const sharedInputProps = {
-    onBlur: () => handleSave(),
-    onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter") handleSave();
-      if (e.key === "Escape") {
-        setActiveField(null);
-        setTempValue("");
-      }
-    },
-    autoFocus: true,
-    onChange: (e: ChangeEvent<HTMLInputElement>) => {
-      setTempValue(e.target.value);
-    },
-    value: tempValue,
-  };
 
   return (
     <div className="px-4 py-8 sm:px-8">

--- a/frontend/src/components/SectionHeader.tsx
+++ b/frontend/src/components/SectionHeader.tsx
@@ -1,0 +1,8 @@
+const SectionHeader = ({ label }: { label: string }) => (
+  <div className="flex items-center gap-3 mb-4">
+    <span className="text-xs font-medium text-ink-muted tracking-[0.01em]">{label}</span>
+    <div className="flex-1 h-px bg-border" />
+  </div>
+);
+
+export default SectionHeader;

--- a/frontend/src/components/TradeEntryDetail.tsx
+++ b/frontend/src/components/TradeEntryDetail.tsx
@@ -1,12 +1,11 @@
-import { useQueryClient, useMutation, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   deleteTradeEntry,
   getTradeEntry,
   updateTradeEntry,
 } from "../api/api.js";
 import { queryKeys } from "../api/queryKeys";
-import { useParams, useNavigate } from "react-router-dom";
-import { useState, useRef, useEffect, ChangeEvent, KeyboardEvent } from "react";
+import { useParams } from "react-router-dom";
 import TextEditor from "./TextEditor.js";
 import ImageUpload from "./ImageUpload";
 import { TradeEntry } from "../types/tradeEntry.types.js";
@@ -20,77 +19,50 @@ import {
 import Select from "./Select";
 import LoadingSpinner from "./LoadingSpinner";
 import ErrorState from "./ErrorState";
+import { useEntryDetail } from "../hooks/useEntryDetail";
+import SectionHeader from "./SectionHeader";
 
-const SectionHeader = ({ label }: { label: string }) => (
-  <div className="flex items-center gap-3 mb-4">
-    <span className="text-xs font-medium text-ink-muted tracking-[0.01em]">{label}</span>
-    <div className="flex-1 h-px bg-border" />
-  </div>
-);
+const NUMERIC_FIELDS = ["contracts", "entryPrice", "exitPrice", "stopLoss", "target"];
 
 const TradeDetail = () => {
   const { id } = useParams<{ id: string }>();
-  const [activeField, setActiveField] = useState<string | null>(null);
-  const [tempValue, setTempValue] = useState<string | number>("");
-  const [saveStatus, setSaveStatus] = useState<"idle" | "saved" | "error">("idle");
-  const [deleteConfirming, setDeleteConfirming] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const queryClient = useQueryClient();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    return () => {
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-      if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
-    };
-  }, []);
 
   const {
-    data: entry,
+    entry,
     isLoading,
     error,
-  } = useQuery<TradeEntry>({
+    saveStatus,
+    deleteConfirming,
+    deleteError,
+    handleSave,
+    handleDeleteClick,
+    handleDeleteCancel,
+    handleDeleteConfirm,
+    activate,
+    activeField,
+    sharedInputProps,
+    deleteMutation,
+    updateMutation,
+  } = useEntryDetail<TradeEntry>({
+    id: id!,
     queryKey: queryKeys.tradeEntry(id!),
     queryFn: () => {
       if (!id) throw new Error("No id provided");
       return getTradeEntry(id);
     },
-    enabled: !!id,
+    updateFn: (payload) => {
+      const coerced: Record<string, unknown> = { ...payload };
+      for (const k of NUMERIC_FIELDS) {
+        if (k in coerced) coerced[k] = Number(coerced[k]);
+      }
+      return updateTradeEntry(coerced as Parameters<typeof updateTradeEntry>[0]);
+    },
+    deleteFn: deleteTradeEntry,
   });
 
   const { data: accounts } = useQuery({
     queryKey: queryKeys.accounts(),
     queryFn: getAccounts,
-  });
-
-  const updateTradeMutation = useMutation({
-    mutationFn: updateTradeEntry,
-    onSuccess: (data) => {
-      queryClient.setQueryData(queryKeys.tradeEntry(id!), data);
-      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
-      setSaveStatus("saved");
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = setTimeout(() => setSaveStatus("idle"), 2000);
-    },
-    onError: () => {
-      setSaveStatus("error");
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: deleteTradeEntry,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
-      navigate("/dashboard");
-    },
-    onError: () => {
-      setDeleteConfirming(false);
-      setDeleteError("Could not delete. Try again.");
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = setTimeout(() => setDeleteError(null), 4000);
-    },
   });
 
   if (isLoading) return <LoadingSpinner message="Loading trade details..." />;
@@ -115,63 +87,6 @@ const TradeDetail = () => {
 
   const formattedEntry = entryTime && formatDateTime(entryTime);
   const formattedExit = exitTime && formatDateTime(exitTime);
-
-  const handleSave = (value = tempValue, field = activeField): void => {
-    if (field) {
-      if (!id) throw new Error("No id provided");
-      let finalValue = value;
-      if (
-        field === "contracts" ||
-        field === "entryPrice" ||
-        field === "exitPrice" ||
-        field === "stopLoss" ||
-        field === "target"
-      ) {
-        finalValue = Number(value);
-      }
-      updateTradeMutation.mutate({ id, [field]: finalValue });
-      setActiveField(null);
-      setTempValue("");
-    }
-  };
-
-  const handleDeleteClick = () => {
-    setDeleteConfirming(true);
-    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
-    deleteTimerRef.current = setTimeout(() => setDeleteConfirming(false), 4000);
-  };
-
-  const handleDeleteCancel = () => {
-    setDeleteConfirming(false);
-    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
-  };
-
-  const handleDeleteConfirm = () => {
-    if (!id) return;
-    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
-    deleteMutation.mutate(id);
-  };
-
-  const activate = (field: string, value: string | number) => {
-    setActiveField(field);
-    setTempValue(value);
-  };
-
-  const sharedInputProps = {
-    onBlur: () => handleSave(),
-    onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter") handleSave();
-      if (e.key === "Escape") {
-        setActiveField(null);
-        setTempValue("");
-      }
-    },
-    autoFocus: true,
-    onChange: (e: ChangeEvent<HTMLInputElement>) => {
-      setTempValue(e.target.value);
-    },
-    value: tempValue,
-  };
 
   return (
     <div className="px-4 py-8 sm:px-8">
@@ -390,7 +305,7 @@ const TradeDetail = () => {
                 maxImages={10}
                 onChange={(urls) => {
                   if (!id) return;
-                  updateTradeMutation.mutate({ id, images: urls });
+                  updateMutation.mutate({ id, images: urls });
                 }}
               />
             </div>

--- a/frontend/src/hooks/useEntryDetail.ts
+++ b/frontend/src/hooks/useEntryDetail.ts
@@ -1,0 +1,135 @@
+import { useQueryClient, useMutation, useQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { useState, useRef, useEffect, ChangeEvent, KeyboardEvent } from "react";
+import { queryKeys } from "../api/queryKeys";
+
+interface UseEntryDetailParams<TEntry> {
+  id: string;
+  queryKey: readonly unknown[];
+  queryFn: () => Promise<TEntry>;
+  updateFn: (payload: { id: string; [key: string]: unknown }) => Promise<TEntry>;
+  deleteFn: (id: string) => Promise<unknown>;
+}
+
+export function useEntryDetail<TEntry>({
+  id,
+  queryKey,
+  queryFn,
+  updateFn,
+  deleteFn,
+}: UseEntryDetailParams<TEntry>) {
+  const [activeField, setActiveField] = useState<string | null>(null);
+  const [tempValue, setTempValue] = useState<string | number>("");
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saved" | "error">("idle");
+  const [deleteConfirming, setDeleteConfirming] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+    };
+  }, []);
+
+  const { data: entry, isLoading, error } = useQuery<TEntry>({
+    queryKey,
+    queryFn,
+    enabled: !!id,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: updateFn,
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKey, data);
+      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
+      setSaveStatus("saved");
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => setSaveStatus("idle"), 2000);
+    },
+    onError: () => {
+      setSaveStatus("error");
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteFn(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.allEntries() });
+      navigate("/dashboard");
+    },
+    onError: () => {
+      setDeleteConfirming(false);
+      setDeleteError("Could not delete. Try again.");
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => setDeleteError(null), 4000);
+    },
+  });
+
+  const handleSave = (value: string | number = tempValue, field: string | null = activeField): void => {
+    if (field) {
+      updateMutation.mutate({ id, [field]: value });
+      setActiveField(null);
+      setTempValue("");
+    }
+  };
+
+  const handleDeleteClick = () => {
+    setDeleteConfirming(true);
+    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+    deleteTimerRef.current = setTimeout(() => setDeleteConfirming(false), 4000);
+  };
+
+  const handleDeleteCancel = () => {
+    setDeleteConfirming(false);
+    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+  };
+
+  const handleDeleteConfirm = () => {
+    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+    deleteMutation.mutate();
+  };
+
+  const activate = (field: string, value: string | number) => {
+    setActiveField(field);
+    setTempValue(value);
+  };
+
+  const sharedInputProps = {
+    onBlur: () => handleSave(),
+    onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") handleSave();
+      if (e.key === "Escape") {
+        setActiveField(null);
+        setTempValue("");
+      }
+    },
+    autoFocus: true as const,
+    onChange: (e: ChangeEvent<HTMLInputElement>) => {
+      setTempValue(e.target.value);
+    },
+    value: tempValue,
+  };
+
+  return {
+    entry,
+    isLoading,
+    error,
+    saveStatus,
+    deleteConfirming,
+    deleteError,
+    handleSave,
+    handleDeleteClick,
+    handleDeleteCancel,
+    handleDeleteConfirm,
+    activate,
+    activeField,
+    tempValue,
+    sharedInputProps,
+    deleteMutation,
+    updateMutation,
+  };
+}


### PR DESCRIPTION
## Summary
- Extracted shared `useEntryDetail<TEntry>` hook to `frontend/src/hooks/useEntryDetail.ts` — owns the entry query, update/delete mutations, save-timer state machine, timer refs, and navigation on delete
- `TradeEntryDetail` and `NoTradeEntryDetail` now delegate all shared logic to the hook and render only their distinct fields (~80 lines removed from each)
- Extracted `SectionHeader` to `frontend/src/components/SectionHeader.tsx` — was defined identically across 4 components (`TradeEntryDetail`, `NoTradeEntryDetail`, `NewTradeEntry`, `NewNoTradeEntry`)

## Test plan
- [ ] Playwright E2E tests pass locally (3/3)
- [ ] Inline field editing (click, type, blur/Enter) saves correctly on trade detail
- [ ] Delete confirmation flow (4s timeout, confirm, cancel) works on both detail views
- [ ] Image upload triggers save on both detail views
- [ ] Save status indicator ("Saved") appears and fades after edits

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)